### PR TITLE
Sink ship rework

### DIFF
--- a/src/components/UserGuessBoard.test.tsx
+++ b/src/components/UserGuessBoard.test.tsx
@@ -17,7 +17,6 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.unguessed,
             name: null,
-            sunk: false,
           }))
       );
 
@@ -48,7 +47,6 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.hit,
             name: null,
-            sunk: false,
           }))
       );
 
@@ -78,7 +76,6 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.miss,
             name: null,
-            sunk: false,
           }))
       );
 
@@ -107,7 +104,6 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.unguessed,
             name: null,
-            sunk: false,
           }))
       );
 
@@ -141,7 +137,6 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.hit,
             name: null,
-            sunk: false,
           }))
       );
 
@@ -178,7 +173,6 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.unguessed,
             name: null,
-            sunk: false,
           }))
       );
 
@@ -215,11 +209,10 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.hit,
             name: 'carrier' as ShipNames,
-            sunk: true,
           }))
       );
 
-    mockComputerShips[0][0] = { status: CellStates.unguessed, name: 'carrier', sunk: false };
+    mockComputerShips[0][0] = { status: CellStates.unguessed, name: 'carrier' };
 
     render(
       <GameContext.Provider
@@ -260,7 +253,6 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.unguessed,
             name: null,
-            sunk: false,
           }))
       );
 
@@ -287,7 +279,6 @@ describe('UserGuessBoard', () => {
           expect.objectContaining({
             status: CellStates.miss,
             name: null,
-            sunk: false,
           }),
         ]),
       ])
@@ -303,14 +294,13 @@ describe('UserGuessBoard', () => {
           .map(() => ({
             status: CellStates.unguessed,
             name: null,
-            sunk: false,
           }))
       );
 
     // Set up different states in first row
-    mockComputerShips[0][0] = { status: CellStates.hit, name: null, sunk: false };
-    mockComputerShips[0][1] = { status: CellStates.miss, name: null, sunk: false };
-    mockComputerShips[0][2] = { status: CellStates.unguessed, name: null, sunk: false };
+    mockComputerShips[0][0] = { status: CellStates.hit, name: null };
+    mockComputerShips[0][1] = { status: CellStates.miss, name: null };
+    mockComputerShips[0][2] = { status: CellStates.unguessed, name: null };
 
     render(
       <GameContext.Provider
@@ -339,8 +329,8 @@ describe('UserGuessBoard', () => {
     };
 
     // Set a specific cell status to test
-    mockContext.computerShips[0][0] = { name: 'ship', status: CellStates.hit, sunk: false };
-    mockContext.computerShips[0][1] = { name: null, status: CellStates.miss, sunk: false };
+    mockContext.computerShips[0][0] = { name: 'ship', status: CellStates.hit };
+    mockContext.computerShips[0][1] = { name: null, status: CellStates.miss };
 
     render(
       <GameContext.Provider value={mockContext}>
@@ -360,8 +350,8 @@ describe('UserGuessBoard', () => {
 
     const computerShips = Array(10)
       .fill(null)
-      .map(() => Array(10).fill({ name: null, status: CellStates.unguessed, sunk: false }));
-    computerShips[0][0] = { name: 'carrier', status: CellStates.hit, sunk: false };
+      .map(() => Array(10).fill({ name: null, status: CellStates.unguessed }));
+    computerShips[0][0] = { name: 'carrier', status: CellStates.hit };
 
     render(
       <GameContext.Provider
@@ -390,8 +380,8 @@ describe('UserGuessBoard', () => {
 
     const computerShips = Array(10)
       .fill(null)
-      .map(() => Array(10).fill({ name: null, status: CellStates.unguessed, sunk: false }));
-    computerShips[0][0] = { name: null, status: CellStates.miss, sunk: false };
+      .map(() => Array(10).fill({ name: null, status: CellStates.unguessed }));
+    computerShips[0][0] = { name: null, status: CellStates.miss };
 
     render(
       <GameContext.Provider
@@ -426,7 +416,7 @@ describe('UserGuessBoard', () => {
           {
             computerShips: Array(10)
               .fill(null)
-              .map(() => Array(10).fill({ name: null, status: CellStates.unguessed, sunk: false })),
+              .map(() => Array(10).fill({ name: null, status: CellStates.unguessed })),
             setComputerShips: mockSetComputerShips,
             playerTurn: 'computer',
             setPlayerTurn: mockSetPlayerTurn,

--- a/src/components/UserGuessBoard.tsx
+++ b/src/components/UserGuessBoard.tsx
@@ -7,7 +7,6 @@ export const UserGuessBoard: React.FC = () => {
   const { computerShips, setComputerShips, playerTurn, setPlayerTurn, addToLog, gameEnded, setGameEnded } =
     React.useContext(GameContext);
 
-
   const columnMarkers = [];
   for (let i = 0; i <= 10; i++) {
     columnMarkers.push(
@@ -66,7 +65,6 @@ export const UserGuessBoard: React.FC = () => {
               setComputerShips(newComputerShips);
               addToLog(`User guessed ${letters[y]}${x + 1}, miss`);
             }
-
 
             setPlayerTurn('computer');
             // setUserShips(newComputerShips); // TODO - Remove this, it's wrong, it's just for testing the heat map

--- a/src/components/UserGuessBoard.tsx
+++ b/src/components/UserGuessBoard.tsx
@@ -45,9 +45,9 @@ export const UserGuessBoard: React.FC = () => {
             const shipIsHere = cell && cell.name;
 
             if (shipIsHere) {
-              newComputerShips[y][x] = { ...cell, status: CellStates.hit, sunk: false };
+              newComputerShips[y][x] = { ...cell, status: CellStates.hit };
               const shipIsSunk = isShipSunk(cell.name as ShipNames, newComputerShips);
-              newComputerShips[y][x] = { ...cell, status: CellStates.hit, sunk: shipIsSunk };
+              newComputerShips[y][x] = { ...cell, status: CellStates.hit };
 
               addToLog(`User guessed ${letters[y]}${x + 1}, hit`);
               if (shipIsSunk) {
@@ -61,7 +61,7 @@ export const UserGuessBoard: React.FC = () => {
                 }
               }
             } else {
-              newComputerShips[y][x] = { name: null, status: CellStates.miss, sunk: false };
+              newComputerShips[y][x] = { name: null, status: CellStates.miss };
               setComputerShips(newComputerShips);
               addToLog(`User guessed ${letters[y]}${x + 1}, miss`);
             }

--- a/src/logic/calculateHeatMap.test.ts
+++ b/src/logic/calculateHeatMap.test.ts
@@ -32,7 +32,7 @@ describe('generateMatchingBoard', () => {
     const boardWithHit: PositionArray = Array(10)
       .fill(null)
       .map(() => Array(10).fill(0));
-    boardWithHit[0][0] = { name: 'destroyer' as ShipNames, status: CellStates.hit, sunk: false };
+    boardWithHit[0][0] = { name: 'destroyer' as ShipNames, status: CellStates.hit };
 
     const result = generateMatchingBoard(boardWithHit);
     expect(result[0][0]).toBeTruthy();
@@ -43,7 +43,7 @@ describe('generateMatchingBoard', () => {
     const boardWithMiss: PositionArray = Array(10)
       .fill(null)
       .map(() => Array(10).fill(0));
-    boardWithMiss[0][0] = { name: null, status: CellStates.miss, sunk: false };
+    boardWithMiss[0][0] = { name: null, status: CellStates.miss };
 
     const result = generateMatchingBoard(boardWithMiss);
     expect(result[0][0]).toBeFalsy();
@@ -109,7 +109,7 @@ describe('initialiseHeatMap', () => {
 describe('calculateHeatMap', () => {
   test('should return 100% for cells that are hits', () => {
     const board = initialiseShipArray();
-    board[4][5] = { name: 'destroyer', status: CellStates.hit, sunk: false };
+    board[4][5] = { name: 'destroyer', status: CellStates.hit };
 
     const heatMap = calculateHeatMap(board);
     expect(heatMap[4][5]).toBe(heatMapIterations);
@@ -117,7 +117,7 @@ describe('calculateHeatMap', () => {
 
   test('should return 0% for cells that are misses', () => {
     const board = initialiseShipArray();
-    board[4][5] = { name: null, status: CellStates.miss, sunk: false };
+    board[4][5] = { name: null, status: CellStates.miss };
 
     const heatMap = calculateHeatMap(board);
     expect(heatMap[4][5]).toBe(0);
@@ -125,12 +125,12 @@ describe('calculateHeatMap', () => {
 
   test('miss cells should not have heat, even when adjacent to hit cells', () => {
     const board = initialiseShipArray();
-    board[4][5] = { name: 'destroyer', status: CellStates.hit, sunk: false };
-    board[4][6] = { name: null, status: CellStates.miss, sunk: false };
-    board[4][4] = { name: null, status: CellStates.miss, sunk: false };
+    board[4][5] = { name: 'destroyer', status: CellStates.hit };
+    board[4][6] = { name: null, status: CellStates.miss };
+    board[4][4] = { name: null, status: CellStates.miss };
 
-    board[3][5] = { name: null, status: CellStates.miss, sunk: false };
-    board[5][5] = { name: null, status: CellStates.miss, sunk: false };
+    board[3][5] = { name: null, status: CellStates.miss };
+    board[5][5] = { name: null, status: CellStates.miss };
 
     const heatMap = calculateHeatMap(board);
     expect(heatMap[4][6]).toBe(0);
@@ -155,11 +155,11 @@ describe('calculateHeatMap', () => {
     const x = 5;
     const y = 5;
 
-    board[y][x] = { name: null, status: CellStates.unguessed, sunk: false };
-    board[y][x + 1] = { name: null, status: CellStates.miss, sunk: false };
-    board[y][x - 1] = { name: null, status: CellStates.miss, sunk: false };
-    board[y + 1][x] = { name: null, status: CellStates.miss, sunk: false };
-    board[y - 1][x] = { name: null, status: CellStates.miss, sunk: false };
+    board[y][x] = { name: null, status: CellStates.unguessed };
+    board[y][x + 1] = { name: null, status: CellStates.miss };
+    board[y][x - 1] = { name: null, status: CellStates.miss };
+    board[y + 1][x] = { name: null, status: CellStates.miss };
+    board[y - 1][x] = { name: null, status: CellStates.miss };
 
     const heatMap = calculateHeatMap(board);
     expect(heatMap[4][5]).toBe(0);
@@ -179,7 +179,7 @@ describe('calculateHeatMap', () => {
     const existingBoard = Array(10)
       .fill(null)
       .map(() => Array(10).fill(null));
-    existingBoard[5][5] = { status: CellStates.hit, sunk: false };
+    existingBoard[5][5] = { status: CellStates.hit };
 
     const result = calculateHeatMap(existingBoard);
     expect(result[5][4]).toBeGreaterThan(0);
@@ -218,7 +218,7 @@ describe('shipSpaceIsAvailable', () => {
     const existingPositions = Array(10)
       .fill(null)
       .map(() => Array(10).fill(null));
-    existingPositions[0][1] = { name: 'ship', status: CellStates.unguessed, sunk: false };
+    existingPositions[0][1] = { name: 'ship', status: CellStates.unguessed };
 
     const result = shipSpaceIsAvailable({
       proposedPositions: {
@@ -236,7 +236,7 @@ describe('shipSpaceIsAvailable', () => {
     const existingBoard = Array(10)
       .fill(null)
       .map(() => Array(10).fill(null));
-    existingBoard[0][1] = { status: CellStates.miss, sunk: false };
+    existingBoard[0][1] = { status: CellStates.miss };
 
     const result = shipSpaceIsAvailable({
       proposedPositions: {

--- a/src/logic/calculateHeatMap.ts
+++ b/src/logic/calculateHeatMap.ts
@@ -67,11 +67,11 @@ export const generateMatchingBoard = (existingBoard: PositionArray): PositionArr
             // Place the ship
             if (alignment === 'horizontal') {
               for (let i = proposedColumn; i < proposedColumn + ship.size; i++) {
-                positions[proposedRow][i] = { name: ship.name, status: CellStates.unguessed, sunk: false };
+                positions[proposedRow][i] = { name: ship.name, status: CellStates.unguessed };
               }
             } else {
               for (let i = proposedRow; i < proposedRow + ship.size; i++) {
-                positions[i][proposedColumn] = { name: ship.name, status: CellStates.unguessed, sunk: false };
+                positions[i][proposedColumn] = { name: ship.name, status: CellStates.unguessed };
               }
             }
 
@@ -110,7 +110,6 @@ export const generateMatchingBoard = (existingBoard: PositionArray): PositionArr
             positions[proposedPositions.startingRow][i] = {
               name: ship.name,
               status: CellStates.unguessed,
-              sunk: false,
             };
           }
         } else {
@@ -118,7 +117,6 @@ export const generateMatchingBoard = (existingBoard: PositionArray): PositionArr
             positions[i][proposedPositions.startingColumn] = {
               name: ship.name,
               status: CellStates.unguessed,
-              sunk: false,
             };
           }
         }

--- a/src/logic/helpers.ts
+++ b/src/logic/helpers.ts
@@ -2,7 +2,6 @@ import { Alignment, CellStates, PositionArray, ShipNames } from '../types';
 import { GameContext } from '../GameContext';
 import { useContext } from 'react';
 
-
 export const generateRandomAlignment = (): Alignment => (Math.random() < 0.5 ? 'horizontal' : 'vertical');
 
 // Return a boolean to confirm whether the ship can fit or whether it would go off the side of the board at the proposed position
@@ -67,4 +66,3 @@ export const declareWinner = (player: 'user' | 'computer'): string => {
     return 'LOSER';
   }
 };
-

--- a/src/logic/makeComputerGuess.test.tsx
+++ b/src/logic/makeComputerGuess.test.tsx
@@ -27,7 +27,6 @@ describe('useMakeComputerGuess', () => {
           .map(() => ({
             name: null as ShipNames | null,
             status: CellStates.unguessed,
-            sunk: false,
           }))
       );
 
@@ -65,10 +64,9 @@ describe('useMakeComputerGuess', () => {
           .map(() => ({
             name: null,
             status: CellStates.unguessed,
-            sunk: false,
           }))
       );
-    userShips[2][3] = { name: 'destroyer', status: CellStates.unguessed, sunk: false };
+    userShips[2][3] = { name: 'destroyer', status: CellStates.unguessed };
 
     const { result } = renderHook(() => useMakeComputerGuess(), {
       wrapper: ({ children }) => (
@@ -157,10 +155,9 @@ describe('useMakeComputerGuess', () => {
           .map(() => ({
             name: null,
             status: CellStates.unguessed,
-            sunk: false,
           }))
       );
-    userShips[1][1] = { name: 'destroyer', status: CellStates.hit, sunk: false }; // Already hit
+    userShips[1][1] = { name: 'destroyer', status: CellStates.hit }; // Already hit
 
     const { result } = renderHook(() => useMakeComputerGuess(), {
       wrapper: ({ children }) => (
@@ -214,7 +211,6 @@ describe('useMakeComputerGuess', () => {
           .map(() => ({
             name: null,
             status: CellStates.unguessed,
-            sunk: false,
           }))
       );
 

--- a/src/logic/makeComputerGuess.ts
+++ b/src/logic/makeComputerGuess.ts
@@ -5,7 +5,6 @@ import { calculateHeatMap } from './calculateHeatMap';
 import { ai } from '../ai-behaviour';
 import { checkAllShipsSunk, declareWinner, isShipSunk } from './helpers';
 
-
 const letters = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J'];
 
 export const useMakeComputerGuess = () => {
@@ -33,30 +32,17 @@ export const useMakeComputerGuess = () => {
     if (cell?.status === CellStates.unguessed || !cell) {
       const newUserShips = [...userShips.map((row) => [...row])];
 
-      let sunk = false;
       const status = cell?.name ? CellStates.hit : CellStates.miss;
-
-      newUserShips[y][x] = {
-        name: cell?.name || null,
-        status,
-        sunk,
-      };
-
-      if (cell?.name) {
-        // If there is a ship here, check whether it is now fully sunk
-        sunk = isShipSunk(cell.name as ShipNames, newUserShips);
-      }
 
       setUserShips(newUserShips);
       addToLog(`Computer guessed ${letters[y]}${x + 1}, ${status}`);
 
-      if (sunk) {
+      if (isShipSunk(cell?.name as ShipNames, newUserShips)) {
         addToLog(`Computer sunk ${cell?.name}`);
 
         if (checkAllShipsSunk(newUserShips)) {
           addToLog(declareWinner('computer'));
         }
-
       }
     }
   }, [userShips, setUserShips, addToLog]);

--- a/src/logic/placeShips.test.ts
+++ b/src/logic/placeShips.test.ts
@@ -147,7 +147,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('returns false when the proposed positions overlap with existing ships', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[0][1] = { name: 'battleship', status: CellStates.miss, sunk: false };
+    existingPositions[0][1] = { name: 'battleship', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 0, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -172,7 +172,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('returns false when a ship overlaps another ship at the edge of the board', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[0][8] = { name: 'carrier', status: CellStates.miss, sunk: false };
+    existingPositions[0][8] = { name: 'carrier', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 6, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -198,7 +198,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in row below', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 0, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -212,7 +212,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in row below', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 0, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -226,7 +226,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in row above', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 2, startingColumn: 0, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -240,7 +240,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in row above', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 2, startingColumn: 0, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -254,7 +254,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in column to left', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -268,7 +268,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in column to left', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -282,7 +282,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in column to right', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -296,7 +296,7 @@ describe('checkValidShipState - horizontal', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in column to right', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -310,8 +310,8 @@ describe('checkValidShipState - horizontal', () => {
 
   test('should return true for a 1 tile long ship in top left corner', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[0][1] = { name: 'submarine', status: CellStates.hit, sunk: false };
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.hit, sunk: false };
+    existingPositions[0][1] = { name: 'submarine', status: CellStates.hit };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.hit };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 0, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -352,7 +352,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('returns false when the proposed positions overlap with existing ships', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'battleship', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'battleship', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 0, alignment: 'vertical' as 'horizontal' | 'vertical' },
@@ -377,7 +377,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('returns false when a ship overlaps another ship at the edge of the board', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[0][6] = { name: 'carrier', status: CellStates.miss, sunk: false };
+    existingPositions[0][6] = { name: 'carrier', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 6, alignment: 'vertical' as 'horizontal' | 'vertical' },
@@ -403,7 +403,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in row below', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[3][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[3][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 0, alignment: 'vertical' as 'horizontal' | 'vertical' },
@@ -417,7 +417,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in row below', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[3][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[3][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 0, startingColumn: 0, alignment: 'vertical' as 'horizontal' | 'vertical' },
@@ -431,7 +431,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in row above', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[0][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[0][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 0, alignment: 'vertical' as 'horizontal' | 'vertical' },
@@ -445,7 +445,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in row above', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[0][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[0][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 0, alignment: 'vertical' as 'horizontal' | 'vertical' },
@@ -459,7 +459,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in column to left', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -473,7 +473,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in column to left', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][0] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -487,7 +487,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are 100% allowed, returns true when a different ship is already in column to right', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },
@@ -501,7 +501,7 @@ describe('checkValidShipState - vertical', () => {
 
   test('when adjacent ships are not allowed, returns false when a different ship is already in column to right', () => {
     let existingPositions = initialiseShipArray();
-    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss, sunk: false };
+    existingPositions[1][4] = { name: 'submarine', status: CellStates.miss };
 
     const props = {
       proposedPositions: { startingRow: 1, startingColumn: 1, alignment: 'horizontal' as 'horizontal' | 'vertical' },

--- a/src/logic/placeShips.ts
+++ b/src/logic/placeShips.ts
@@ -91,7 +91,6 @@ export const placeShips = (): PositionArray => {
             positions[proposedPositions.startingRow][i] = {
               name: ship.name,
               status: CellStates.unguessed,
-              sunk: false,
             };
           }
         } else {
@@ -100,7 +99,6 @@ export const placeShips = (): PositionArray => {
             positions[i][proposedPositions.startingColumn] = {
               name: ship.name,
               status: CellStates.unguessed,
-              sunk: false,
             };
           }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,6 @@ export enum CellStates {
   unguessed = 'unguessed',
 }
 
-export type PositionArray = ({ name: ShipNames | null; status: CellStates; sunk: boolean } | null)[][];
+export type PositionArray = ({ name: ShipNames | null; status: CellStates } | null)[][];
 
 export type Alignment = 'horizontal' | 'vertical';


### PR DESCRIPTION
In my last pull request I added a property to each ship to identify whether it was sunk or not. However, I am not using that to identify whether all the ships are sunk or not. In fact, it's not even helpful and the code can correctly identify sunk ships based on whether every square is a hit.

I have therefore refactored the code to remove this sunk property and updated the tests accordingly.